### PR TITLE
Add PHP 7.4 version test during Travis CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: php
 
 php:
   - 7.3
+  - 7.4
 
 before_script:
   - travis_retry composer install --prefer-dist --no-interaction


### PR DESCRIPTION
# Changed log

- Add `php-7.4` version test during Travis CI build.